### PR TITLE
Allow matrix attribute prefix to be shorter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,11 +8,11 @@ let
       "x86_64-darwin" = "macos-12";
     };
 
-    # Return a Gitub Actions matrix from a package set shaped like
+    # Return a GitHub Actions matrix from a package set shaped like
     # the Flake attribute packages/checks.
     mkGithubMatrix =
       { checks # Takes an attrset shaped like { x86_64-linux = { hello = pkgs.hello; }; }
-      , attrPrefix ? "githubActions"
+      , attrPrefix ? "githubActions.checks"
       , platforms ? self.githubPlatforms
       }: {
         inherit checks;
@@ -30,8 +30,8 @@ let
                         if builtins.typeOf os == "list" then os else [ os ];
                       attr = (
                         if attrPrefix != ""
-                        then "${attrPrefix}.checks.${system}.${attr}"
-                        else "checks.${system}.${attr}"
+                        then "${attrPrefix}.${system}.${attr}"
+                        else "${system}.${attr}"
                       );
                     })
                   (attrNames pkgs)


### PR DESCRIPTION
When setting `attrPrefix` to `""`, there is still a hard-coded prefix of `checks.`, but longer-than-necessary prefixes make it hard to discern different matrix entries in the Actions web interface.

This simple change makes the whole prefix optional, while keeping the existing default behaviour. As a side effect, users who have set `attrPrefix` to `""` will find that they no longer have the `"checks."` prefix, but this is very unlikely to cause issues for them because they will generally only have matrix entries in their Workflow that have been generated by the code in this repo.