### PR TITLE
Remove attrPrefix and run the expected check attrs

### DIFF
--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -29,4 +29,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22
-      - run: nix build -L ".#${{ matrix.attr }}"
+      - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,6 @@ let
     # the Flake attribute packages/checks.
     mkGithubMatrix =
       { checks # Takes an attrset shaped like { x86_64-linux = { hello = pkgs.hello; }; }
-      , attrPrefix ? "githubActions.checks"
       , platforms ? self.githubPlatforms
       }: {
         inherit checks;
@@ -28,11 +27,7 @@ let
                           os = platforms.${system};
                         in
                         if builtins.typeOf os == "list" then os else [ os ];
-                      attr = (
-                        if attrPrefix != ""
-                        then "${attrPrefix}.${system}.${attr}"
-                        else "${system}.${attr}"
-                      );
+                      attr = "${system}.${attr}";
                     })
                   (attrNames pkgs)
               )


### PR DESCRIPTION
When my PR #4 was merged, I noticed that a build broke for my client repo, in which I was setting "attrPrefix". And I realised that either the intention of "attrPrefix" and the "githubActions.checks" attribute are not clear, or there was an error.

Specifically, I was setting attrPrefix to `""`, and then the generation Actions yml file was building `.#${{matrix.attr}}`, so it was trying to build `.#x86_64-linux.emacs-24-3`, for example, and of course that attribute doesn't exist. But what I expected, and *what I think you probably planned*, was that the `githubActions.checks` attribute is used *both* to generate the matrix, *and* to run those checks later. After all, I can't see why we'd look in one place for checks to run, and then look them up in a different place later — or perhaps I'm missing something.

Anyway, this suggested change makes everything match up: there's no longer an `attrPrefix`, and the Action steps run `.#githubActions.checks.${{matrix.attr}}`.

(Related to #4 and #7.)