### PR TITLE
Fix nix-matrix job status

### DIFF
--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -19,7 +19,8 @@ jobs:
         name: Generate Nix Matrix
         run: |
           set -Eeu
-          echo "matrix=$(nix eval --json '.#githubActions.matrix')" >> "$GITHUB_OUTPUT"
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   nix-build:
     needs: nix-matrix


### PR DESCRIPTION
The nix-matrix job was reported as successful when in reality the nix eval command had a non-zero exit code and failed to generate the matrix. By splitting the echo and nix eval commands up into two lines the exit code is properly detected and fails the nix-matrix job.

Fixes #15. I honestly have no idea why splitting this up into two lines makes a difference with `set -Eeu`, but apparently it does as you can see here: https://github.com/matrss/nixfiles/commit/4e6c7af589da91f0190ae132f473833bf0cc9742 and here: https://github.com/matrss/nixfiles/actions/runs/7357536847/job/20029309636 after I made this change in my nixfiles repository.