### PR TITLE
Fix builds if attr names contain dots

### DIFF
--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -30,4 +30,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
-      - run: nix build -L ".#${{ matrix.attr }}"
+      - run: nix build -L '.#${{ matrix.attr }}'

--- a/default.nix
+++ b/default.nix
@@ -30,8 +30,8 @@ let
                         if builtins.typeOf os == "list" then os else [ os ];
                       attr = (
                         if attrPrefix != ""
-                        then "${attrPrefix}.${system}.${attr}"
-                        else "${system}.${attr}"
+                        then "${attrPrefix}.${system}.\"${attr}\""
+                        else "${system}.\"${attr}\""
                       );
                     })
                   (attrNames pkgs)


### PR DESCRIPTION
Keys in attrsets can contain dots, but they must be properly quoted in the shell.

Fixes #17.