### PR TITLE
Enable new aarch64-darwin runner macos-14

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,40 +6,37 @@ let
     githubPlatforms = {
       "x86_64-linux" = "ubuntu-22.04";
       "x86_64-darwin" = "macos-12";
+      "aarch64-darwin" = "macos-14";
     };
 
     # Return a GitHub Actions matrix from a package set shaped like
     # the Flake attribute packages/checks.
     mkGithubMatrix =
-      { checks # Takes an attrset shaped like { x86_64-linux = { hello = pkgs.hello; }; }
-      , attrPrefix ? "githubActions.checks"
-      , platforms ? self.githubPlatforms
-      }: {
+      {
+        checks, # Takes an attrset shaped like { x86_64-linux = { hello = pkgs.hello; }; }
+        attrPrefix ? "githubActions.checks",
+        platforms ? self.githubPlatforms,
+      }:
+      {
         inherit checks;
         matrix = {
-          include = flatten (attrValues (
-            mapAttrs
-              (
-                system: pkgs: builtins.map
-                  (attr:
-                    {
-                      os =
-                        let
-                          os = platforms.${system};
-                        in
-                        if builtins.typeOf os == "list" then os else [ os ];
-                      attr = (
-                        if attrPrefix != ""
-                        then "${attrPrefix}.${system}.${attr}"
-                        else "${system}.${attr}"
-                      );
-                    })
-                  (attrNames pkgs)
-              )
-              checks));
+          include = flatten (
+            attrValues (
+              mapAttrs (
+                system: pkgs:
+                builtins.map (attr: {
+                  os =
+                    let
+                      os = platforms.${system};
+                    in
+                    if builtins.typeOf os == "list" then os else [ os ];
+                  attr = (if attrPrefix != "" then "${attrPrefix}.${system}.${attr}" else "${system}.${attr}");
+                }) (attrNames pkgs)
+              ) checks
+            )
+          );
         };
       };
   };
-
 in
 self

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,17 @@
 {
   description = "Generate Github Actions matrices from Nix Flakes";
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      eachSystem = systems: fn: builtins.foldl' (acc: system: acc // { ${system} = (fn system); }) { } systems;
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
-
+      eachSystem =
+        systems: fn: builtins.foldl' (acc: system: acc // { ${system} = (fn system); }) { } systems;
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+        "aarch64-linux"
+      ];
     in
     {
       lib = import ./default.nix;
@@ -13,12 +19,13 @@
       githubActions = self.lib.mkGithubMatrix {
         # Inherit GHA actions matrix from a subset of platforms supported by hosted runners
         checks = {
-          inherit (self.checks) x86_64-linux x86_64-darwin;
+          inherit (self.checks) x86_64-linux x86_64-darwin aarch64-darwin;
         };
       };
 
       # Just regular flake checks
-      checks = eachSystem supportedSystems (system:
+      checks = eachSystem supportedSystems (
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
@@ -27,20 +34,27 @@
             nixpkgs-fmt --check ${self}
             touch $out
           '';
-        });
+        }
+      );
 
       # Development shell to hack on this
-      devShells = eachSystem supportedSystems (system:
+      devShells = eachSystem supportedSystems (
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
           default = pkgs.mkShell {
-            packages = [ pkgs.nixpkgs-fmt pkgs.python3 ];
+            packages = [
+              pkgs.nixpkgs-fmt
+              pkgs.python3
+            ];
           };
-        });
+        }
+      );
 
-      apps = eachSystem supportedSystems (system:
+      apps = eachSystem supportedSystems (
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
@@ -57,7 +71,7 @@
             };
 
           default = self.apps.${system}.quickstart;
-        });
-
+        }
+      );
     };
 }


### PR DESCRIPTION
Add support for the new apple silicon runners made available this year.