### PR TITLE
Add MacOS ARM platform

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ let
     githubPlatforms = {
       "x86_64-linux" = "ubuntu-22.04";
       "x86_64-darwin" = "macos-12";
+      "aarch64-darwin" = "macos-14";
     };
 
     # Return a GitHub Actions matrix from a package set shaped like


### PR DESCRIPTION
Now that the [macos-14 runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) is available, we can support aarch64-darwin here.