### PR TITLE
Add name and system attributes to matrix output

### DIFF
--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -20,6 +20,7 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   nix-build:
+    name: ${{ matrix.name }} (${{ matrix.system }})
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -3,9 +3,6 @@ name: Nix Flake actions
 on:
   pull_request:
   push:
-    branches:
-      - master
-      - main
 
 jobs:
   nix-matrix:

--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,8 @@ let
                 system: pkgs: builtins.map
                   (attr:
                     {
+                      name = attr;
+                      inherit system;
                       os =
                         let
                           os = platforms.${system};


### PR DESCRIPTION
This makes it easier to give the jobs shorter names. `name` contains the attribute name, as opposed to `attr` which contains the entire attribute path.