### PR TITLE
feat: support aarch64-linux

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ let
 
   self = {
     githubPlatforms = {
-      "x86_64-linux" = "ubuntu-22.04";
+      "x86_64-linux" = "ubuntu-24.04";
       "x86_64-darwin" = "macos-13";
       "aarch64-darwin" = "macos-14";
     };

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let
       "x86_64-linux" = "ubuntu-24.04";
       "x86_64-darwin" = "macos-13";
       "aarch64-darwin" = "macos-14";
+      "aarch64-linux" = "ubuntu-24.04-arm";
     };
 
     # Return a GitHub Actions matrix from a package set shaped like


### PR DESCRIPTION
c.f. https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
